### PR TITLE
Force ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,13 @@ concuerror = $(CONCUERROR_RUN) -f $(BUILD_DIR)/concuerror+test/lib/snabbkaffe/te
 
 .PHONY: concuerror_test
 concuerror_test: $(CONCUERROR)
-	rebar3 as concuerror eunit
+	rebar3 as concuerror eunit -m concuerror_tests
 	$(call concuerror,race_test)
 	$(call concuerror,causality_test)
 	$(call concuerror,fail_test)
 	$(call concuerror,force_order_test)
 	$(call concuerror,force_order_multiple_predicates)
+	$(call concuerror,force_order_parametrized)
 
 $(CONCUERROR):
 	mkdir -p _build/

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ concuerror_test: $(CONCUERROR)
 	$(call concuerror,race_test)
 	$(call concuerror,causality_test)
 	$(call concuerror,fail_test)
+	$(call concuerror,force_order_test)
+	$(call concuerror,force_order_multiple_predicates)
 
 $(CONCUERROR):
 	mkdir -p _build/

--- a/README.org
+++ b/README.org
@@ -254,6 +254,23 @@ this race condition:
 do_stuff(Pid)
 #+END_SRC
 
+** Blocking execution of the SUT until certain event is emitted
+
+Sometimes it is necessary to test a certain process
+scheduling. Imagine writing a regression test verifying absence of a
+certain bug, that happens only when an event =bar= happens after an
+event =foo=. Snabbkaffe trace points could be used to artificially
+delay execution of the processes and enforce the expected ordering of
+the events:
+
+#+BEGIN_SRC erlang
+%% run stage...
+?force_ordering(#{?snk_kind := foo, ...}, #{?snk_kind := bar})
+#+END_SRC
+
+This will cause the process that tries to produce an event of kind
+=foo= to wait for another process to produce the event of kind =bar=.
+
 ** Declarative fault injection
 
 Any trace point can also be used to inject crashes into the

--- a/include/snabbkaffe.hrl
+++ b/include/snabbkaffe.hrl
@@ -45,10 +45,13 @@
 -define(maybe_crash(DATA),
         snabbkaffe_nemesis:maybe_crash(?__snkStaticUniqueToken, DATA)).
 
--define(force_ordering(DELAY_PATTERN, CONTINUE_PATTERN),
-        snabbkaffe_nemesis:inject_delay( ?snk_int_match_arg(CONTINUE_PATTERN)
-                                       , ?snk_int_match_arg(DELAY_PATTERN)
+-define(force_ordering(CONTINUE_PATTERN, DELAY_PATTERN, GUARD),
+        snabbkaffe_nemesis:inject_delay( ?snk_int_match_arg(DELAY_PATTERN)
+                                       , ?snk_int_match_arg2(DELAY_PATTERN, CONTINUE_PATTERN, GUARD)
                                        )).
+
+-define(force_ordering(CONTINUE_PATTERN, DELAY_PATTERN),
+        ?force_ordering(CONTINUE_PATTERN, DELAY_PATTERN, true)).
 
 -define(tp(LEVEL, KIND, EVT),
         snabbkaffe:tp(?__snkStaticUniqueToken, LEVEL, KIND, EVT)).

--- a/include/snabbkaffe.hrl
+++ b/include/snabbkaffe.hrl
@@ -11,31 +11,6 @@
 
 -ifdef(SNK_COLLECTOR).
 
--define(panic(KIND, ARGS),
-        error({panic, (ARGS) #{?snk_kind => (KIND)}})).
-
-%% Dirty hack: we use reference to a local function as a key that can
-%% be used to refer error injection points. This works, because all
-%% invokations of this macro create a new fun object with unique id.
--define(__snkStaticUniqueToken, fun() -> ok end).
-
--define(maybe_crash(KIND, DATA),
-        snabbkaffe_nemesis:maybe_crash(KIND, DATA#{?snk_kind => KIND})).
-
--define(maybe_crash(DATA),
-        snabbkaffe_nemesis:maybe_crash(?__snkStaticUniqueToken, DATA)).
-
--define(tp(LEVEL, KIND, EVT),
-        snabbkaffe:tp(?__snkStaticUniqueToken, LEVEL, KIND, EVT)).
-
--define(tp(KIND, EVT), ?tp(debug, KIND, EVT)).
-
--define(of_kind(KIND, TRACE),
-        snabbkaffe:events_of_kind(KIND, TRACE)).
-
--define(projection(FIELDS, TRACE),
-        snabbkaffe:projection(FIELDS, TRACE)).
-
 -define(snk_int_match_arg(ARG),
         fun(__SnkArg) ->
             case __SnkArg of
@@ -55,6 +30,36 @@
               _ -> false
             end
         end).
+
+-define(panic(KIND, ARGS),
+        error({panic, (ARGS) #{?snk_kind => (KIND)}})).
+
+%% Dirty hack: we use reference to a local function as a key that can
+%% be used to refer error injection points. This works, because all
+%% invokations of this macro create a new fun object with unique id.
+-define(__snkStaticUniqueToken, fun() -> ok end).
+
+-define(maybe_crash(KIND, DATA),
+        snabbkaffe_nemesis:maybe_crash(KIND, DATA#{?snk_kind => KIND})).
+
+-define(maybe_crash(DATA),
+        snabbkaffe_nemesis:maybe_crash(?__snkStaticUniqueToken, DATA)).
+
+-define(force_ordering(DELAY_PATTERN, CONTINUE_PATTERN),
+        snabbkaffe_nemesis:inject_delay( ?snk_int_match_arg(CONTINUE_PATTERN)
+                                       , ?snk_int_match_arg(DELAY_PATTERN)
+                                       )).
+
+-define(tp(LEVEL, KIND, EVT),
+        snabbkaffe:tp(?__snkStaticUniqueToken, LEVEL, KIND, EVT)).
+
+-define(tp(KIND, EVT), ?tp(debug, KIND, EVT)).
+
+-define(of_kind(KIND, TRACE),
+        snabbkaffe:events_of_kind(KIND, TRACE)).
+
+-define(projection(FIELDS, TRACE),
+        snabbkaffe:projection(FIELDS, TRACE)).
 
 -define(find_pairs(STRICT, M1, M2, GUARD, TRACE),
         snabbkaffe:find_pairs( STRICT

--- a/src/snabbkaffe.erl
+++ b/src/snabbkaffe.erl
@@ -126,6 +126,7 @@ tp(Location, Level, Kind, Data) ->
 -spec local_tp(term(), logger:level(), kind(), map()) -> ok.
 local_tp(Location, _Level, Kind, Data) ->
   Event = Data #{?snk_kind => Kind},
+  snabbkaffe_nemesis:maybe_delay(Event),
   snabbkaffe_nemesis:maybe_crash(Location, Event),
   snabbkaffe_collector:tp(Event).
 

--- a/src/snabbkaffe.erl
+++ b/src/snabbkaffe.erl
@@ -101,6 +101,8 @@
 
 -type predicate() :: fun((event()) -> boolean()).
 
+-type predicate2() :: fun((event(), event()) -> boolean()).
+
 -export_type([ kind/0, timestamp/0, event/0, timed_event/0, trace/0
              , maybe_pair/0, maybe/1, metric/0, run_config/0, predicate/0
              ]).

--- a/src/snabbkaffe_nemesis.erl
+++ b/src/snabbkaffe_nemesis.erl
@@ -43,6 +43,9 @@
         , inject_crash/3
         , fix_crash/1
         , maybe_crash/2
+          %% Delay
+        , inject_delay/2
+        , maybe_delay/1
           %% Failure scenarios
         , always_crash/0
         , recover_after/1
@@ -60,6 +63,7 @@
 
 -define(ERROR_TAB, snabbkaffe_injected_errors).
 -define(STATE_TAB, snabbkaffe_fault_states).
+-define(DELAY_TAB, snabbkaffe_injected_delays).
 -define(SINGLETON_KEY, 0).
 
 %%%===================================================================
@@ -86,17 +90,25 @@
 %% Injected error:
 -record(fault,
         { reference :: reference()
-        , predicate :: snabbkaffe:prediacate()
+        , predicate :: snabbkaffe:predicate()
         , scenario  :: snabbkaffe:fault_scenario()
         , reason    :: term()
+        }).
+
+%% Injected delay:
+-record(delay,
+        { reference          :: reference()
+        , delay_predicate    :: snabbkaffe:predicate() % Event that is being delayed
+        , continue_predicate :: snabbkaffe:predicate() % Event that unlocks execution of the delayed process
         }).
 
 %% Currently this gen_server just holds the ets tables and
 %% synchronizes writes to the fault table, but in the future it may be
 %% used to mess up the system in more interesting ways
 -record(s,
-        { injected_errors :: ets:tid()
-        , fault_states    :: ets:tid()
+        { injected_errors         :: ets:tid()
+        , fault_states            :: ets:tid()
+        , injected_delays         :: ets:tid()
         }).
 
 %%%===================================================================
@@ -137,24 +149,42 @@ maybe_crash(Key, Data) ->
   %% Check if any of the injected errors have predicates matching my
   %% data:
   Fun = fun(#fault{predicate = P}) -> P(Data) end,
-  case lists:filter(Fun, Faults) of
-    [] ->
-      %% None of the injected faults match my data:
-      ok;
-    [#fault{scenario = S, reason = R}|_] ->
-      NewVal = ets:update_counter(?STATE_TAB, Key, {2, 1}, {Key, 0}),
-      %% Run fault_scenario function to see if we need to crash this
-      %% time:
-      case S(NewVal) of
-        true ->
-          snabbkaffe_collector:tp(Data#{ crash_kind => Key
-                                       , ?snk_kind  => snabbkaffe_crash
-                                       }),
-          error(R);
-        false ->
-          ok
-      end
-  end.
+  [begin
+     NewVal = ets:update_counter(?STATE_TAB, Key, {2, 1}, {Key, 0}),
+     %% Run fault_scenario function to see if we need to crash this
+     %% time:
+     case S(NewVal) of
+       true ->
+         snabbkaffe_collector:tp(Data#{ crash_kind => Key
+                                      , ?snk_kind  => snabbkaffe_crash
+                                      }),
+         error(R);
+       false ->
+         ok
+     end
+   end
+   || #fault{scenario = S, reason = R} <- lists:filter(Fun, Faults)],
+  ok.
+
+%% @doc Inject delay into the system
+-spec inject_delay(snabbkaffe:predicate(), snabbkaffe:predicate()) -> reference().
+inject_delay(DelayPredicate, ContinuePredicate) ->
+  Ref = make_ref(),
+  Delay = #delay{ reference          = Ref
+                , delay_predicate    = DelayPredicate
+                , continue_predicate = ContinuePredicate
+                },
+  ok = gen_server:call(?SERVER, {inject_delay, Delay}, infinity),
+  Ref.
+
+%% @doc Check if the trace point should be delayed.
+-spec maybe_delay(map()) -> ok.
+maybe_delay(Event) ->
+  [{_, Delays}] = ets:lookup(?DELAY_TAB, ?SINGLETON_KEY),
+  Fun = fun(#delay{delay_predicate = P}) -> P(Event) end,
+  [snabbkaffe_collector:block_until(Pred, infinity, infinity)
+   || #delay{reference = Ref, continue_predicate = Pred} <- lists:filter(Fun, Delays)],
+  ok.
 
 %%%===================================================================
 %%% Fault scenarios
@@ -207,9 +237,16 @@ init([]) ->
                            , {read_concurrency, true}
                            , protected
                            ]),
+  DT = ets:new(?DELAY_TAB, [ named_table
+                           , {write_concurrency, false}
+                           , {read_concurrency, true}
+                           , public
+                           ]),
   ets:insert(?ERROR_TAB, {?SINGLETON_KEY, []}),
+  ets:insert(?DELAY_TAB, {?SINGLETON_KEY, []}),
   {ok, #s{ injected_errors = FT
          , fault_states    = ST
+         , injected_delays = DT
          }}.
 
 %% @private
@@ -221,6 +258,10 @@ handle_call({fix_crash, Ref}, _From, State) ->
   [{_, Faults0}] = ets:lookup(?ERROR_TAB, ?SINGLETON_KEY),
   Faults = lists:keydelete(Ref, #fault.reference, Faults0),
   ets:insert(?ERROR_TAB, {?SINGLETON_KEY, Faults}),
+  {reply, ok, State};
+handle_call({inject_delay, Delay}, _From, State) ->
+  [{_, Delays}] = ets:lookup(?DELAY_TAB, ?SINGLETON_KEY),
+  ets:insert(?DELAY_TAB, {?SINGLETON_KEY, [Delay|Delays]}),
   {reply, ok, State};
 handle_call(_Request, _From, State) ->
   {reply, ok, State}.

--- a/test/causality_tests.erl
+++ b/test/causality_tests.erl
@@ -36,6 +36,12 @@
                   , Trace
                   )).
 
+%% Weak Cuasality With Guard
+-define(WCWG(Trace),
+        ?causality( #{foo := _A}, #{bar := _B}, _A + 1 =:= _B
+                  , Trace
+                  )).
+
 -define(foo(A), #{foo => A}).
 -define(bar(A), #{bar => A}).
 
@@ -90,6 +96,22 @@ fpng_success_test() ->
                       ])
               ).
 
+wcwg_succ_test() ->
+  ?assertMatch( false
+              , ?WCWG([])
+              ),
+  ?assertMatch( true
+              , ?WCWG([?foo(1)])
+              ),
+  ?assertMatch( true
+              , ?WCWG([?foo(1), ?bar(2)])
+              ).
+
+wcwg_fail_test() ->
+  ?assertError( {panic, _}
+              , ?WCWG([?foo(2), ?bar(1)])
+              ).
+
 fpng_scoped_test() ->
   %% Test that match specs in ?find_pairs capture variables from the
   %% context:
@@ -112,6 +134,11 @@ spwg_success_test() ->
               ),
   ?assertMatch( [?singleton(1), ?pair_inc(2)]
               , ?SPWG([?foo(1), ?foo(2), foo, ?bar(3), bar])
+              ).
+
+spwg_fail_test() ->
+  ?assertError( {panic, _}
+              , ?SPWG([?foo(2), ?bar(1)])
               ).
 
 scng_succ_test() ->

--- a/test/concuerror_tests.erl
+++ b/test/concuerror_tests.erl
@@ -8,6 +8,7 @@
         , fail_test/0
         , force_order_test/0
         , force_order_multiple_predicates/0
+        , force_order_parametrized/0
         ]).
 
 race_test() ->
@@ -94,7 +95,6 @@ fail_test() ->
     _:_ -> ok
   end.
 
-
 %% Check that ordering of events is correct when ?force_ordering is used
 force_order_test() ->
   ?check_trace(
@@ -111,8 +111,8 @@ force_order_test() ->
        [?block_until(#{?snk_kind := second, id := I}) || I <- [1,2]]
      end,
      fun(_Result, Trace) ->
-         ?strict_causality(#{?snk_kind := first}, #{?snk_kind := second, id := 1}, Trace),
-         ?strict_causality(#{?snk_kind := first}, #{?snk_kind := second, id := 2}, Trace)
+         ?assert(?strict_causality(#{?snk_kind := first}, #{?snk_kind := second, id := 1}, Trace)),
+         ?assert(?strict_causality(#{?snk_kind := first}, #{?snk_kind := second, id := 2}, Trace))
      end).
 
 %% Check waiting for multiple events
@@ -129,6 +129,34 @@ force_order_multiple_predicates() ->
        {ok, _} = ?block_until(#{?snk_kind := foo})
      end,
      fun(_Result, Trace) ->
-         true = ?strict_causality(#{?snk_kind := bar}, #{?snk_kind := foo}, Trace),
-         true = ?strict_causality(#{?snk_kind := baz}, #{?snk_kind := foo}, Trace)
+         ?assert(?strict_causality(#{?snk_kind := bar}, #{?snk_kind := foo}, Trace)),
+         ?assert(?strict_causality(#{?snk_kind := baz}, #{?snk_kind := foo}, Trace))
+     end).
+
+%% Check parameter bindings in force_ordering
+force_order_parametrized() ->
+  ?check_trace(
+     begin
+       ?force_ordering( #{?snk_kind := foo, id := _A}
+                      , #{?snk_kind := bar, id := _A}
+                      ),
+       spawn(
+         fun() ->
+             ?tp(bar, #{id => 1})
+         end),
+       spawn(
+         fun() ->
+             ?tp(bar, #{id => 2})
+         end),
+       timer:sleep(100),
+       ?tp(foo, #{id => 1}),
+       ?tp(foo, #{id => 2}),
+       ?block_until(#{?snk_kind := bar, id := 1}),
+       ?block_until(#{?snk_kind := bar, id := 2})
+     end,
+     fun(_, Trace) ->
+         ?assert(?strict_causality( #{?snk_kind := foo, id := _A}
+                                  , #{?snk_kind := bar, id := _A}
+                                  , Trace
+                                  ))
      end).

--- a/test/concuerror_tests.erl
+++ b/test/concuerror_tests.erl
@@ -3,7 +3,12 @@
 -include("snabbkaffe.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
--export([race_test/0, causality_test/0, fail_test/0]).
+-export([ race_test/0
+        , causality_test/0
+        , fail_test/0
+        , force_order_test/0
+        , force_order_multiple_predicates/0
+        ]).
 
 race_test() ->
   ?check_trace(
@@ -88,3 +93,42 @@ fail_test() ->
   catch
     _:_ -> ok
   end.
+
+
+%% Check that ordering of events is correct when ?force_ordering is used
+force_order_test() ->
+  ?check_trace(
+     begin
+       ?force_ordering(#{?snk_kind := first}, #{?snk_kind := second}),
+       spawn(fun() ->
+                 ?tp(second, #{id => 1})
+             end),
+       spawn(fun() ->
+                 ?tp(second, #{id => 2})
+             end),
+       timer:sleep(100),
+       ?tp(first, #{}),
+       [?block_until(#{?snk_kind := second, id := I}) || I <- [1,2]]
+     end,
+     fun(_Result, Trace) ->
+         ?strict_causality(#{?snk_kind := first}, #{?snk_kind := second, id := 1}, Trace),
+         ?strict_causality(#{?snk_kind := first}, #{?snk_kind := second, id := 2}, Trace)
+     end).
+
+%% Check waiting for multiple events
+force_order_multiple_predicates() ->
+  ?check_trace(
+     begin
+       ?force_ordering(#{?snk_kind := baz}, #{?snk_kind := foo}),
+       ?force_ordering(#{?snk_kind := bar}, #{?snk_kind := foo}),
+       spawn(fun() ->
+                 ?tp(foo, #{})
+             end),
+       ?tp(bar, #{}),
+       ?tp(baz, #{}),
+       {ok, _} = ?block_until(#{?snk_kind := foo})
+     end,
+     fun(_Result, Trace) ->
+         true = ?strict_causality(#{?snk_kind := bar}, #{?snk_kind := foo}, Trace),
+         true = ?strict_causality(#{?snk_kind := baz}, #{?snk_kind := foo}, Trace)
+     end).

--- a/test/remote_funs.erl
+++ b/test/remote_funs.erl
@@ -14,3 +14,14 @@ remote_tp() ->
 
 remote_crash() ->
   ?assertError(notmyday, ?tp(remote_fail, #{})).
+
+remote_delay() ->
+  spawn(
+    fun() ->
+        ?tp(bar, #{id => 1})
+    end),
+  spawn(
+    fun() ->
+        ?tp(bar, #{id => 2})
+    end),
+  ok.


### PR DESCRIPTION
Limitation: injected delays can't be removed. I tried implementing it, but encountered a couple surprisingly difficult to fix problems. Hopefully, no one needs removal feature.