### PR TITLE
Silence the unused variable warnings

### DIFF
--- a/include/trace_prod.hrl
+++ b/include/trace_prod.hrl
@@ -11,10 +11,22 @@
                     , file => ?FILE
                     })).
 
--define(tp(KIND, EVT), ok).
+-define(tp(KIND, EVT),
+        begin
+          _ = EVT, %% Silence "unused variable" warnings. This term should be dropped by the compiler
+          ok
+        end).
 
--define(maybe_crash(KIND, DATA), ok).
+-define(maybe_crash(KIND, DATA),
+        begin
+          _ = DATA,
+          ok
+        end).
 
--define(maybe_crash(DATA), ok).
+-define(maybe_crash(DATA),
+        begin
+          _ = DATA,
+          ok
+        end).
 
 -endif.


### PR DESCRIPTION
This PR should fix the unused variable warnings that appear in the release build when some variables are used only in `tp` macros. Unfortunately, the compiler doesn't drop the unused variable bindings and still emits some useless code.