### PR TITLE
feat: Code locations in the trace dump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [24.1.7.0, 21.3.8.21]
+        otp: [25.2, 21.3.8.21]
     container:
       image: erlang:${{ matrix.otp }}
 

--- a/doc/src/running.md
+++ b/doc/src/running.md
@@ -41,6 +41,8 @@ basic_test() ->
 
 If either run stage or check stage fails, `?check_trace` dumps the collected trace to a file and throws an exception that is detected by eunit or Common Test.
 The trace dumps are placed to `snabbkaffe` sub-directory of the current working directory.
+By default snabbkaffe dumps all the events as is, but if `SNK_PRETTY_PRINT_DUMP` OS environment variable is set, then it prefixes trace events with file and line of the source code file that produced the event.
+It is useful for debugging and troubleshooting.
 
 If the return value from the run stage is not needed in the check stage, it can be omitted:
 

--- a/include/trace_test.hrl
+++ b/include/trace_test.hrl
@@ -6,7 +6,12 @@
 %% Dirty hack: we use reference to a local function as a key that can
 %% be used to refer error injection points. This works, because all
 %% invokations of this macro create a new fun object with unique id.
--define(__snkStaticUniqueToken, fun() -> ok end).
+%%
+%% Note: the returned tuple doesn't play any role for snabbkaffe,
+%% since it compares fun objects rather than return values.
+%%
+%% But it's used for pretty printing of the trace dump.
+-define(__snkStaticUniqueToken, fun() -> {?FILE, ?LINE} end).
 
 -define(tp(LEVEL, KIND, EVT),
         snabbkaffe:tp(?__snkStaticUniqueToken, LEVEL, KIND, EVT)).

--- a/test/remote_SUITE.erl
+++ b/test/remote_SUITE.erl
@@ -6,6 +6,8 @@
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("snabbkaffe/include/ct_boilerplate.hrl").
 
+-compile(nowarn_deprecated_function). %% Silence the warnings about slave module
+
 %%====================================================================
 %% CT callbacks
 %%====================================================================

--- a/test/run_SUITE.erl
+++ b/test/run_SUITE.erl
@@ -141,6 +141,18 @@ t_silence_interval_timetrap(Cfg) when is_list(Cfg) ->
       error(no_timetrap)
   end.
 
+t_pretty_print(Cfg) when is_list(Cfg) ->
+  try
+    os:putenv("SNK_PRETTY_PRINT_DUMP", "true"),
+    snabbkaffe:start_trace(),
+    ?tp(test_event, #{foo => bar}),
+    ?tp(test_event2, #{foo => bar}),
+    Trace = snabbkaffe:collect_trace(),
+    snabbkaffe:dump_trace(Trace)
+  after
+    os:unsetenv("SNK_PRETTY_PRINT_DUMP")
+  end.
+
 %%====================================================================
 %% Internal functions
 %%====================================================================


### PR DESCRIPTION
...Make it easier to jump to the trace events

Example:
```
snabbkaffe/test/concuerror_tests.erl:128  #{'$kind' => foo,'~meta' => #{gl => <0.1313.0>,node => nonode@nohost,pid => <0.1281.0>,time => -576460748125839}}.
```