### PR TITLE
feat: readable timestamp in trace dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.6
+### Features
+- Add timestamp of the trace events in the trace dump
+- Show timestamp and code location (`file:line`) of the trace events by default (environment variable `SNK_PRETTY_PRINT_DUMP` is not used anymore).
+
 ## 1.0.5
 ### Features
 - OTP25 support
@@ -76,7 +81,7 @@
 - Fix race condition in the injected fault
 
 ### Features
-- Improved event subscription mechanism using new APIs: `snabbkaffe_collector:subcribe` and `receive_events`, that aim to replace the `?wait_async_action` macro:
+- Improved event subscription mechanism using new APIs: `snabbkaffe_collector:subscribe` and `receive_events`, that aim to replace the `?wait_async_action` macro:
 
 ```erlang
 {ok, Sub} = snabbkaffe_collector:subscribe( ?match_event(#{?snk_kind := foo})

--- a/doc/src/running.md
+++ b/doc/src/running.md
@@ -41,7 +41,7 @@ basic_test() ->
 
 If either run stage or check stage fails, `?check_trace` dumps the collected trace to a file and throws an exception that is detected by eunit or Common Test.
 The trace dumps are placed to `snabbkaffe` sub-directory of the current working directory.
-By default snabbkaffe dumps all the events as is, but if `SNK_PRETTY_PRINT_DUMP` OS environment variable is set, then it prefixes trace events with file and line of the source code file that produced the event.
+Dumped snabbkaffe trace events are prefixed with a timestamp, file and line of the source code file that produced the event.
 It is useful for debugging and troubleshooting.
 
 If the return value from the run stage is not needed in the check stage, it can be omitted:

--- a/src/snabbkaffe_collector.erl
+++ b/src/snabbkaffe_collector.erl
@@ -33,6 +33,7 @@
 
 %% Internal exports
 -export([ wait_for_silence/1
+        , make_begin_trace/0
         ]).
 
 %% gen_server callbacks
@@ -185,16 +186,20 @@ wait_for_silence(SilenceInterval) when SilenceInterval > 0 ->
 get_last_event_ts() ->
   gen_server:call(?SERVER, get_last_event_ts, infinity).
 
+
+make_begin_trace() ->
+    #{ ts                => timestamp()
+     , begin_system_time => os:system_time(microsecond)
+     , ?snk_kind         => '$trace_begin'
+     }.
+
 %%%===================================================================
 %%% gen_server callbacks
 %%%===================================================================
 
 init([]) ->
   persistent_term:put(?PT_TP_FUN, fun snabbkaffe:local_tp/5),
-  TS = timestamp(),
-  BeginTrace = #{ ts        => TS
-                , ?snk_kind => '$trace_begin'
-                },
+  #{ts := TS} = BeginTrace = make_begin_trace(),
   {ok, #s{ trace         = [BeginTrace]
          , last_event_ts = TS
          }}.

--- a/test/run_SUITE.erl
+++ b/test/run_SUITE.erl
@@ -142,16 +142,11 @@ t_silence_interval_timetrap(Cfg) when is_list(Cfg) ->
   end.
 
 t_pretty_print(Cfg) when is_list(Cfg) ->
-  try
-    os:putenv("SNK_PRETTY_PRINT_DUMP", "true"),
-    snabbkaffe:start_trace(),
-    ?tp(test_event, #{foo => bar}),
-    ?tp(test_event2, #{foo => bar}),
-    Trace = snabbkaffe:collect_trace(),
-    snabbkaffe:dump_trace(Trace)
-  after
-    os:unsetenv("SNK_PRETTY_PRINT_DUMP")
-  end.
+  snabbkaffe:start_trace(),
+  ?tp(test_event, #{foo => bar}),
+  ?tp(test_event2, #{foo => bar}),
+  Trace = snabbkaffe:collect_trace(),
+  snabbkaffe:dump_trace(Trace).
 
 %%====================================================================
 %% Internal functions


### PR DESCRIPTION
sample dump:
```
2023-02-23T17:43:45.728244+00:00 '$trace_begin' #{'~meta' => #{begin_system_time => 1677174225728244,time => -576460733930099}}.
2023-02-23T17:43:45.728285+00:00 call_query_enter #{id => <<"id">>,query => {query,undefined,block,false,infinity},'~meta' => #{gl => <0.3413.0>,location => #Fun<emqx_resource_buffer_worker.38.82834824>,node => nonode@nohost,pid => <0.3935.0>,time => -576460733930058}}. 
2023-02-23T17:43:45.728301+00:00 call_query #{call_mode => sync,id => <<"id">>,mod => emqx_connector_demo,query => {query,undefined,block,false,infinity},res_st => #{id => <<"id:2">>,name => t_async_reply_multi_eval,pid => <0.3939.0>,stop_error => false},'~meta' => #{gl => <0.3413.0>,location => #Fun<emqx_resource_buffer_worker.41.82834824>,node => nonode@nohost
,pid => <0.3935.0>,time => -576460733930042}}.
2023-02-23T17:43:45.764856+00:00 buffer_worker_resume_from_blocked_enter #{'~meta' => #{gl => <0.3928.0>,location => #Fun<emqx_resource_buffer_worker.3.82834824>,node => nonode@nohost,pid => <0.3940.0>,time => -576460733893487}}.
2023-02-23T17:43:45.764980+00:00 buffer_worker_enter_running #{id => <<"id">>,'~meta' => #{gl => <0.3928.0>,location => #Fun<emqx_resource_buffer_worker.1.82834824>,node => nonode@nohost,pid => <0.3940.0>,time => -576460733893363}}.
2023-02-23T17:43:45.765472+00:00 buffer_worker_flush #{inflight => 0,is_inflight_full => false,queued => 0,'~meta' => #{gl => <0.3928.0>,location => #Fun<emqx_resource_buffer_worker.10.82834824>,node => nonode@nohost,pid => <0.3940.0>,time => -576460733892871}}.
2023-02-23T17:43:45.765485+00:00 buffer_worker_queue_drained #{inflight => 0,'~meta' => #{gl => <0.3928.0>,location => #Fun<emqx_resource_buffer_worker.11.82834824>,node => nonode@nohost,pid => <0.3940.0>,time => -576460733892858}}.
2023-02-23T17:43:45.765502+00:00 '$trace_end' #{'~meta' => #{time => -576460733892841}}.
```