### PR TITLE
Fix '$trace_begin' event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.7
+### Non-BC changes
+- Change the format of `$trace_begin` event from `#{?snk_kind => '$trace_begin', ts => ...}` to `#{?snk_kind => '$trace_begin', ?snk_meta => #{time => ...}}`
+
 ## 1.0.6
 ### Features
 - Add timestamp of the trace events in the trace dump

--- a/src/snabbkaffe.erl
+++ b/src/snabbkaffe.erl
@@ -92,7 +92,7 @@
 
 -type timed_event() ::
         #{ ?snk_kind := kind()
-         , ts   := timestamp()
+         , ?snk_meta := #{time := integer(), _ => _}
          , _ => _
          }.
 
@@ -672,7 +672,10 @@ dump_trace(Trace) ->
   FullPath.
 
 format_trace(Trace) ->
-  [#{begin_system_time := BeginTime, ts := BeginMonoTime}] = ?of_kind('$trace_begin', Trace),
+  [#{ ?snk_kind := '$trace_begin'
+    , begin_system_time := BeginTime
+    , ?snk_meta := #{time := BeginMonoTime}
+    }|_] = Trace,
   lists:map(fun(E) -> format_event(BeginTime, BeginMonoTime, E) end, Trace).
 
 format_event(BeginTime, BeginMonoTime, #{?snk_kind := Kind0} = Event0) ->
@@ -706,8 +709,7 @@ location_str(Evt0 = #{?snk_meta := #{location := Fun}}) when is_function(Fun, 0)
 location_str(Evt0) ->
   {"", Evt0}.
 
-event_monotonic_time(#{?snk_meta := #{time := Time}}) -> Time;
-event_monotonic_time(#{ts := Time}) -> Time.
+event_monotonic_time(#{?snk_meta := #{time := Time}}) -> Time.
 
 remove_meta_key(Key, #{?snk_meta := Meta} = Event) ->
   Event#{?snk_meta => maps:remove(Key, Meta)};

--- a/src/snabbkaffe_collector.erl
+++ b/src/snabbkaffe_collector.erl
@@ -1,5 +1,5 @@
-%% Copyright 2019-2020, 2022 Klarna Bank AB
-%% Copyright 2021 snabbkaffe contributors
+%% Copyright 2021-2023 snabbkaffe contributors
+%% Copyright 2019-2020 Klarna Bank AB
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -188,9 +188,9 @@ get_last_event_ts() ->
 
 
 make_begin_trace() ->
-    #{ ts                => timestamp()
+    #{ ?snk_kind         => '$trace_begin'
      , begin_system_time => os:system_time(microsecond)
-     , ?snk_kind         => '$trace_begin'
+     , ?snk_meta         => #{time => timestamp()}
      }.
 
 %%%===================================================================
@@ -199,7 +199,7 @@ make_begin_trace() ->
 
 init([]) ->
   persistent_term:put(?PT_TP_FUN, fun snabbkaffe:local_tp/5),
-  #{ts := TS} = BeginTrace = make_begin_trace(),
+  #{?snk_meta := #{time := TS}} = BeginTrace = make_begin_trace(),
   {ok, #s{ trace         = [BeginTrace]
          , last_event_ts = TS
          }}.

--- a/test/collector_SUITE.erl
+++ b/test/collector_SUITE.erl
@@ -43,8 +43,8 @@ t_check_trace(_Config) when is_list(_Config) ->
      42,
      fun(Ret, Trace) ->
          ?assertMatch(42, Ret),
-         ?assertMatch( [ #{?snk_kind := '$trace_begin'}
-                       , #{?snk_kind := '$trace_end'}
+         ?assertMatch( [ #{?snk_kind := '$trace_begin', ?snk_meta := #{time := _}}
+                       , #{?snk_kind := '$trace_end', ?snk_meta := #{time := _}}
                        ]
                      , Trace)
      end).


### PR DESCRIPTION
Originally there wasn't a dedicated `?snk_meta` field in the event, and timestamps were part of the base map. This PR fixes the forgotten remains of that old event standard. 