### PR TITLE
feat: add `?tp_ignore_side_effects_in_prod/2`

### DIFF
--- a/doc/src/emitting_events.md
+++ b/doc/src/emitting_events.md
@@ -70,6 +70,10 @@ In this case, a different form of `?tp` can be used:
 The first argument of the macro is log level, as used by [logger](https://www.erlang.org/doc/man/logger.html#type-level).
 The others are equivalent to the previous form of the macro.
 
+## ?tp_ignore_side_effects_in_prod
+
+This is made available as tool for optimizing specific use cases.  Usually, one shouldn't rely on side effects inside arguments of `?tp/2`.  If there's a need to introduce a trace point in a certain hot path for test efficiency purposes, but the arguments make expensive calls, then this macro is provided and won't ever evaluate its arguments in a production build.
+
 ## ?tp_span
 
 Sometimes it is useful to emit two events before and after some action executes.

--- a/include/trace_prod.hrl
+++ b/include/trace_prod.hrl
@@ -17,6 +17,8 @@
           ok
         end).
 
+-define(tp_ignore_side_effects_in_prod(_KIND, _EVT), ok).
+
 -define(maybe_crash(KIND, DATA), ok).
 
 -define(maybe_crash(DATA), ok).

--- a/include/trace_test.hrl
+++ b/include/trace_test.hrl
@@ -18,6 +18,8 @@
 
 -define(tp(KIND, EVT), ?tp(debug, KIND, EVT)).
 
+-define(tp_ignore_side_effects_in_prod(KIND, EVT), ?tp(KIND, EVT)).
+
 -define(maybe_crash(KIND, DATA),
         snabbkaffe_nemesis:maybe_crash(KIND, DATA#{?snk_kind => KIND})).
 

--- a/test/prod_log_test.erl
+++ b/test/prod_log_test.erl
@@ -18,3 +18,7 @@ trace_prod_test() ->
 no_unused_variables_test() ->
   A = 1, %% This variable should not be recognized as unused
   ?tp(foo, #{a => A}).
+
+tp_ignore_side_effects_in_prod_test() ->
+  %% Should not evaluate its args at all when in prod.
+  ?tp_ignore_side_effects_in_prod(foo, #{look => error(boom)}).


### PR DESCRIPTION
Sometimes, we might use expensive calls inside `?tp/2` for testing purposes.  But, the tracepoint is in a hot path, then the expensive call will still be called.